### PR TITLE
Shared job library cleanup to support SIMULIZAR-118

### DIFF
--- a/bundles/org.palladiosimulator.analyzer.workflow/src/org/palladiosimulator/analyzer/workflow/ConstantsContainer.java
+++ b/bundles/org.palladiosimulator.analyzer.workflow/src/org/palladiosimulator/analyzer/workflow/ConstantsContainer.java
@@ -101,5 +101,10 @@ public class ConstantsContainer {
 	public static final Boolean DEFAULT_ANALYSE_ACCURACY = false;
 	/** Default value for the sensitivity analysis. */
 	public static final Boolean DEFAULT_DO_SENSITIVITY_ANALYSIS = false;
+	
+	//Default partition IDs
+	public static final String DEFAULT_PCM_INSTANCE_PARTITION_ID = "org.palladiosimulator.pcmmodels.partition";
+	public static final String RMI_MIDDLEWARE_REPOSITORY_PARTITION_ID = "de.uka.ipd.sdq.pcmmodels.partition.rmimiddleware";
+	public static final String EVENT_MIDDLEWARE_REPOSITORY_PARTITION_ID = "de.uka.ipd.sdq.pcmmodels.partition.eventmiddleware";
 
 }

--- a/bundles/org.palladiosimulator.analyzer.workflow/src/org/palladiosimulator/analyzer/workflow/jobs/CreateBlackboardPartitionJob.java
+++ b/bundles/org.palladiosimulator.analyzer.workflow/src/org/palladiosimulator/analyzer/workflow/jobs/CreateBlackboardPartitionJob.java
@@ -1,0 +1,52 @@
+package org.palladiosimulator.analyzer.workflow.jobs;
+
+import java.util.function.Supplier;
+
+import org.apache.log4j.Logger;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+import de.uka.ipd.sdq.workflow.jobs.AbstractBlackboardInteractingJob;
+import de.uka.ipd.sdq.workflow.jobs.CleanupFailedException;
+import de.uka.ipd.sdq.workflow.jobs.JobFailedException;
+import de.uka.ipd.sdq.workflow.jobs.UserCanceledException;
+import de.uka.ipd.sdq.workflow.mdsd.blackboard.MDSDBlackboard;
+import de.uka.ipd.sdq.workflow.mdsd.blackboard.ResourceSetPartition;
+
+public class CreateBlackboardPartitionJob extends AbstractBlackboardInteractingJob<MDSDBlackboard> {
+    
+    /** The logger for this class */
+    private static final Logger LOGGER = Logger.getLogger(CreateBlackboardPartitionJob.class);
+
+    private final String blackboardId;
+    private final Supplier<ResourceSetPartition> partitionSupplier;
+
+    public CreateBlackboardPartitionJob(String blackboardId) {
+        this(blackboardId, ResourceSetPartition::new);
+    }
+    
+    public CreateBlackboardPartitionJob(String blackboardId, Supplier<ResourceSetPartition> partitionSupplier) {
+        this.blackboardId = blackboardId;
+        this.partitionSupplier = partitionSupplier;
+    }
+    
+    @Override
+    public void execute(IProgressMonitor monitor) throws JobFailedException, UserCanceledException {
+        var partition = partitionSupplier.get();
+        
+        if (myBlackboard.hasPartition(blackboardId)) {
+            LOGGER.warn("The blackboard already contained a partition with id:" + blackboardId);
+        }
+        
+        myBlackboard.addPartition(blackboardId, partition);
+    }
+
+    @Override
+    public void cleanup(IProgressMonitor monitor) throws CleanupFailedException {
+    }
+
+    @Override
+    public String getName() {
+        return "Create Blackboard Partition \"" + blackboardId + "\"";
+    }
+
+}

--- a/bundles/org.palladiosimulator.analyzer.workflow/src/org/palladiosimulator/analyzer/workflow/jobs/LoadMiddlewareConfigurationIntoBlackboardJob.java
+++ b/bundles/org.palladiosimulator.analyzer.workflow/src/org/palladiosimulator/analyzer/workflow/jobs/LoadMiddlewareConfigurationIntoBlackboardJob.java
@@ -1,92 +1,31 @@
 package org.palladiosimulator.analyzer.workflow.jobs;
 
-import org.apache.log4j.Logger;
-import org.eclipse.core.runtime.IProgressMonitor;
+import org.palladiosimulator.analyzer.workflow.ConstantsContainer;
 import org.palladiosimulator.analyzer.workflow.configurations.AbstractCodeGenerationWorkflowRunConfiguration;
-import org.palladiosimulator.analyzer.workflow.configurations.AbstractPCMWorkflowRunConfiguration;
 
-import de.uka.ipd.sdq.workflow.jobs.CleanupFailedException;
-import de.uka.ipd.sdq.workflow.jobs.IBlackboardInteractingJob;
-import de.uka.ipd.sdq.workflow.jobs.IJob;
-import de.uka.ipd.sdq.workflow.jobs.JobFailedException;
-import de.uka.ipd.sdq.workflow.jobs.UserCanceledException;
+import de.uka.ipd.sdq.workflow.jobs.SequentialBlackboardInteractingJob;
 import de.uka.ipd.sdq.workflow.mdsd.blackboard.MDSDBlackboard;
-import de.uka.ipd.sdq.workflow.mdsd.blackboard.ResourceSetPartition;
 
-public class LoadMiddlewareConfigurationIntoBlackboardJob 
-implements IJob, IBlackboardInteractingJob<MDSDBlackboard> {
+public class LoadMiddlewareConfigurationIntoBlackboardJob extends SequentialBlackboardInteractingJob<MDSDBlackboard> {
 
-    private static final Logger LOGGER = Logger.getLogger(LoadPCMModelsIntoBlackboardJob.class);
+    @Deprecated
+	public static final String RMI_MIDDLEWARE_PARTITION_ID = ConstantsContainer.RMI_MIDDLEWARE_REPOSITORY_PARTITION_ID;
 	
-	public static final String RMI_MIDDLEWARE_PARTITION_ID = "de.uka.ipd.sdq.pcmmodels.partition.rmimiddleware";
-	public static final String EVENT_MIDDLEWARE_PARTITION_ID = "de.uka.ipd.sdq.pcmmodels.partition.eventmiddleware";
-
-	private MDSDBlackboard blackboard = null;
-	private AbstractPCMWorkflowRunConfiguration configuration = null;
+	@Deprecated
+	public static final String EVENT_MIDDLEWARE_PARTITION_ID = ConstantsContainer.EVENT_MIDDLEWARE_REPOSITORY_PARTITION_ID;
 
 	public LoadMiddlewareConfigurationIntoBlackboardJob(AbstractCodeGenerationWorkflowRunConfiguration config) {
-		super();
-		
-		this.configuration  = config;
-	}
-
-	@Override
-    public void execute(IProgressMonitor monitor) throws JobFailedException,
-			UserCanceledException {
-		ResourceSetPartition middlewareRepositoryPartition = null;
-		if (!this.blackboard.hasPartition(RMI_MIDDLEWARE_PARTITION_ID)) {
-			if(LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Creating RMI Middleware Repository Partition");
-            }
-			
-			middlewareRepositoryPartition = new ResourceSetPartition();
-			this.blackboard.addPartition(RMI_MIDDLEWARE_PARTITION_ID, middlewareRepositoryPartition);
-			
-			if(LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Initialising RMI Middleware EPackages");
-            }
-			middlewareRepositoryPartition.initialiseResourceSetEPackages(AbstractPCMWorkflowRunConfiguration.PCM_EPACKAGES);
-		} else {
-			middlewareRepositoryPartition = this.blackboard.getPartition(RMI_MIDDLEWARE_PARTITION_ID);
-		}
-		middlewareRepositoryPartition.loadModel(configuration.getRMIMiddlewareFile());
-		
-		// load event middleware 
-		ResourceSetPartition eventMiddlewareRepositoryPartition = null;
-		if (!this.blackboard.hasPartition(EVENT_MIDDLEWARE_PARTITION_ID)) {
-			if(LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Creating Event Middleware Repository Partition");
-            }
-			
-			eventMiddlewareRepositoryPartition = new ResourceSetPartition();
-			this.blackboard.addPartition(EVENT_MIDDLEWARE_PARTITION_ID, eventMiddlewareRepositoryPartition);
-			
-			if(LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Initialising Event Middleware EPackages");
-            }
-			eventMiddlewareRepositoryPartition.initialiseResourceSetEPackages(AbstractPCMWorkflowRunConfiguration.PCM_EPACKAGES);
-		} else {
-			eventMiddlewareRepositoryPartition = this.blackboard.getPartition(EVENT_MIDDLEWARE_PARTITION_ID);
-		}
-		if (configuration.getEventMiddlewareFile() != null) {
-			eventMiddlewareRepositoryPartition.loadModel(configuration.getEventMiddlewareFile());
-		}
+        add(new CreateBlackboardPartitionJob(ConstantsContainer.RMI_MIDDLEWARE_REPOSITORY_PARTITION_ID));
+        add(new CreateBlackboardPartitionJob(ConstantsContainer.EVENT_MIDDLEWARE_REPOSITORY_PARTITION_ID));
+        LoadModelIntoBlackboardJob.parseUriAndAddModelLoadJob(config.getRMIMiddlewareFile(),
+                ConstantsContainer.RMI_MIDDLEWARE_REPOSITORY_PARTITION_ID, this);
+        LoadModelIntoBlackboardJob.parseUriAndAddModelLoadJob(config.getEventMiddlewareFile(),
+                ConstantsContainer.EVENT_MIDDLEWARE_REPOSITORY_PARTITION_ID, this);
 	}
 
 	@Override
     public String getName() {
 		return "Load Middleware Configuration into Blackboard";
-	}
-
-	@Override
-    public void cleanup(IProgressMonitor monitor)
-			throws CleanupFailedException {
-		this.blackboard.removePartition(RMI_MIDDLEWARE_PARTITION_ID);
-	}
-
-	@Override
-    public void setBlackboard(MDSDBlackboard blackboard) {
-		this.blackboard = blackboard;
 	}
 
 }

--- a/bundles/org.palladiosimulator.analyzer.workflow/src/org/palladiosimulator/analyzer/workflow/jobs/LoadModelIntoBlackboardJob.java
+++ b/bundles/org.palladiosimulator.analyzer.workflow/src/org/palladiosimulator/analyzer/workflow/jobs/LoadModelIntoBlackboardJob.java
@@ -1,0 +1,62 @@
+package org.palladiosimulator.analyzer.workflow.jobs;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.emf.common.util.URI;
+
+import de.uka.ipd.sdq.workflow.jobs.AbstractBlackboardInteractingJob;
+import de.uka.ipd.sdq.workflow.jobs.CleanupFailedException;
+import de.uka.ipd.sdq.workflow.jobs.ICompositeJob;
+import de.uka.ipd.sdq.workflow.jobs.JobFailedException;
+import de.uka.ipd.sdq.workflow.jobs.UserCanceledException;
+import de.uka.ipd.sdq.workflow.mdsd.blackboard.MDSDBlackboard;
+
+public class LoadModelIntoBlackboardJob extends AbstractBlackboardInteractingJob<MDSDBlackboard> {
+
+    private final URI modelURI;
+    private final String partitionID;
+    
+    public static void parseUriAndAddModelLoadJob(String modelUri, ICompositeJob container) {
+        parseUriAndAddModelLoadJob(modelUri, LoadPCMModelsIntoBlackboardJob.PCM_MODELS_PARTITION_ID, container);
+    }
+    
+    public static void parseUriAndAddModelLoadJob(String modelUri, String partitionId, ICompositeJob container) {
+        if (modelUri == null || modelUri.isBlank()) return;
+        if (partitionId == null || partitionId.isBlank()) return;
+        
+        var uri = URI.createURI(modelUri);
+        container.addJob(new LoadModelIntoBlackboardJob(uri, partitionId));
+    }
+    
+    public LoadModelIntoBlackboardJob(URI modelURI, String partitionID) {
+        this.modelURI = Objects.requireNonNull(modelURI);
+        this.partitionID = Objects.requireNonNull(partitionID);
+    }
+    
+    @Override
+    public void execute(IProgressMonitor monitor) throws JobFailedException, UserCanceledException {
+        var partition = Optional.ofNullable(myBlackboard.getPartition(partitionID))
+            .orElseThrow(() -> new IllegalStateException(String.format("The blackboard does not contain the requested partition \"%s\"", partitionID)));
+
+        if (!partition.getResourceSet().getURIConverter().exists(modelURI, Collections.emptyMap())) {
+            throw new JobFailedException(String.format("Job %s failed: The model uri \"%s\" does not point to a valid file", getName(), modelURI));
+        }
+        
+        partition.loadModel(modelURI);        
+    }
+
+    @Override
+    public void cleanup(IProgressMonitor monitor) throws CleanupFailedException {
+        // Nothing to do here, blackboard partitions are not reused
+    }
+
+    @Override
+    public String getName() {
+        return String.format("LoadModelIntoBlackboardJob<%s->%s>", modelURI.lastSegment(), partitionID);
+    }
+
+
+}

--- a/bundles/org.palladiosimulator.analyzer.workflow/src/org/palladiosimulator/analyzer/workflow/jobs/LoadPCMModelsIntoBlackboardJob.java
+++ b/bundles/org.palladiosimulator.analyzer.workflow/src/org/palladiosimulator/analyzer/workflow/jobs/LoadPCMModelsIntoBlackboardJob.java
@@ -1,5 +1,6 @@
 package org.palladiosimulator.analyzer.workflow.jobs;
 
+import org.palladiosimulator.analyzer.workflow.ConstantsContainer;
 import org.palladiosimulator.analyzer.workflow.blackboard.PCMResourceSetPartition;
 import org.palladiosimulator.analyzer.workflow.configurations.AbstractPCMWorkflowRunConfiguration;
 
@@ -22,7 +23,8 @@ public class LoadPCMModelsIntoBlackboardJob extends SequentialBlackboardInteract
      * ID of the blackboard partition containing the fully loaded PCM instance. The blackboard
      * partition is ensured to be of type {@link PCMResourceSetPartition}
      */
-    public static final String PCM_MODELS_PARTITION_ID = "org.palladiosimulator.pcmmodels.partition";
+    @Deprecated
+    public static final String PCM_MODELS_PARTITION_ID = ConstantsContainer.DEFAULT_PCM_INSTANCE_PARTITION_ID;
 
     /**
      * Constructor of the PCM loader job

--- a/bundles/org.palladiosimulator.analyzer.workflow/src/org/palladiosimulator/analyzer/workflow/jobs/LoadSharedPCMLibrariesIntoBlackboard.java
+++ b/bundles/org.palladiosimulator.analyzer.workflow/src/org/palladiosimulator/analyzer/workflow/jobs/LoadSharedPCMLibrariesIntoBlackboard.java
@@ -1,0 +1,18 @@
+package org.palladiosimulator.analyzer.workflow.jobs;
+
+import org.eclipse.emf.common.util.URI;
+
+import de.uka.ipd.sdq.workflow.jobs.SequentialBlackboardInteractingJob;
+import de.uka.ipd.sdq.workflow.mdsd.blackboard.MDSDBlackboard;
+
+public class LoadSharedPCMLibrariesIntoBlackboard extends SequentialBlackboardInteractingJob<MDSDBlackboard> {
+    public static final URI PCM_PALLADIO_RESOURCE_TYPE_URI = URI
+        .createURI("pathmap://PCM_MODELS/Palladio.resourcetype");
+    public static final URI PCM_PALLADIO_PRIMITIVE_TYPE_REPOSITORY_URI = URI
+        .createURI("pathmap://PCM_MODELS/PrimitiveTypes.repository");
+
+    public LoadSharedPCMLibrariesIntoBlackboard(String partitionId) {
+        add(new LoadModelIntoBlackboardJob(PCM_PALLADIO_PRIMITIVE_TYPE_REPOSITORY_URI, partitionId));
+        add(new LoadModelIntoBlackboardJob(PCM_PALLADIO_RESOURCE_TYPE_URI, partitionId));
+    }
+}

--- a/bundles/org.palladiosimulator.analyzer.workflow/src/org/palladiosimulator/analyzer/workflow/jobs/PreparePCMBlackboardPartitionJob.java
+++ b/bundles/org.palladiosimulator.analyzer.workflow/src/org/palladiosimulator/analyzer/workflow/jobs/PreparePCMBlackboardPartitionJob.java
@@ -1,6 +1,7 @@
 package org.palladiosimulator.analyzer.workflow.jobs;
 
 import org.palladiosimulator.analyzer.workflow.ConstantsContainer;
+import org.palladiosimulator.analyzer.workflow.blackboard.PCMResourceSetPartition;
 
 import de.uka.ipd.sdq.workflow.jobs.SequentialBlackboardInteractingJob;
 import de.uka.ipd.sdq.workflow.mdsd.blackboard.MDSDBlackboard;
@@ -17,7 +18,7 @@ public class PreparePCMBlackboardPartitionJob extends SequentialBlackboardIntera
     }
     
     public PreparePCMBlackboardPartitionJob(String partitionId) {
-        add(new CreateBlackboardPartitionJob(partitionId));
+        add(new CreateBlackboardPartitionJob(partitionId, PCMResourceSetPartition::new));
         add(new LoadSharedPCMLibrariesIntoBlackboard(partitionId));
     }
 

--- a/bundles/org.palladiosimulator.analyzer.workflow/src/org/palladiosimulator/analyzer/workflow/jobs/PreparePCMBlackboardPartitionJob.java
+++ b/bundles/org.palladiosimulator.analyzer.workflow/src/org/palladiosimulator/analyzer/workflow/jobs/PreparePCMBlackboardPartitionJob.java
@@ -1,16 +1,8 @@
 package org.palladiosimulator.analyzer.workflow.jobs;
 
-import org.apache.log4j.Logger;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.emf.common.util.URI;
-import org.palladiosimulator.analyzer.workflow.blackboard.PCMResourceSetPartition;
-import org.palladiosimulator.analyzer.workflow.configurations.AbstractPCMWorkflowRunConfiguration;
+import org.palladiosimulator.analyzer.workflow.ConstantsContainer;
 
-import de.uka.ipd.sdq.workflow.jobs.CleanupFailedException;
-import de.uka.ipd.sdq.workflow.jobs.IBlackboardInteractingJob;
-import de.uka.ipd.sdq.workflow.jobs.IJob;
-import de.uka.ipd.sdq.workflow.jobs.JobFailedException;
-import de.uka.ipd.sdq.workflow.jobs.UserCanceledException;
+import de.uka.ipd.sdq.workflow.jobs.SequentialBlackboardInteractingJob;
 import de.uka.ipd.sdq.workflow.mdsd.blackboard.MDSDBlackboard;
 
 /**
@@ -18,46 +10,19 @@ import de.uka.ipd.sdq.workflow.mdsd.blackboard.MDSDBlackboard;
  * 
  * @author Sebastian Lehrig
  */
-public class PreparePCMBlackboardPartitionJob implements IJob, IBlackboardInteractingJob<MDSDBlackboard> {
-
-    private static final Logger LOGGER = Logger.getLogger(PreparePCMBlackboardPartitionJob.class);
-    private MDSDBlackboard blackboard;
-
-    public static final URI PCM_PALLADIO_RESOURCE_TYPE_URI = URI
-            .createURI("pathmap://PCM_MODELS/Palladio.resourcetype");
-    public static final URI PCM_PALLADIO_PRIMITIVE_TYPE_REPOSITORY_URI = URI
-            .createURI("pathmap://PCM_MODELS/PrimitiveTypes.repository");
-
-    @Override
-    public void execute(final IProgressMonitor monitor) throws JobFailedException, UserCanceledException {
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Creating PCM Model Partition");
-        }
-        final PCMResourceSetPartition pcmPartition = new PCMResourceSetPartition();
-        this.blackboard.addPartition(LoadPCMModelsIntoBlackboardJob.PCM_MODELS_PARTITION_ID, pcmPartition);
-
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Initializing PCM EPackages");
-        }
-        pcmPartition.initialiseResourceSetEPackages(AbstractPCMWorkflowRunConfiguration.PCM_EPACKAGES);
-
-        pcmPartition.loadModel(PCM_PALLADIO_PRIMITIVE_TYPE_REPOSITORY_URI);
-        pcmPartition.loadModel(PCM_PALLADIO_RESOURCE_TYPE_URI);
+public class PreparePCMBlackboardPartitionJob extends SequentialBlackboardInteractingJob<MDSDBlackboard> {
+    
+    public PreparePCMBlackboardPartitionJob() {
+        this(ConstantsContainer.DEFAULT_PCM_INSTANCE_PARTITION_ID);
+    }
+    
+    public PreparePCMBlackboardPartitionJob(String partitionId) {
+        add(new CreateBlackboardPartitionJob(partitionId));
+        add(new LoadSharedPCMLibrariesIntoBlackboard(partitionId));
     }
 
     @Override
     public String getName() {
         return "Prepare PCM Blackboard Partitions";
     }
-
-    @Override
-    public void cleanup(final IProgressMonitor monitor) throws CleanupFailedException {
-        this.blackboard.removePartition(LoadPCMModelsIntoBlackboardJob.PCM_MODELS_PARTITION_ID);
-    }
-
-    @Override
-    public void setBlackboard(final MDSDBlackboard blackboard) {
-        this.blackboard = blackboard;
-    }
-
 }

--- a/bundles/org.palladiosimulator.analyzer.workflow/src/org/palladiosimulator/analyzer/workflow/jobs/ResolveAllModelsOfPartitionJob.java
+++ b/bundles/org.palladiosimulator.analyzer.workflow/src/org/palladiosimulator/analyzer/workflow/jobs/ResolveAllModelsOfPartitionJob.java
@@ -1,0 +1,36 @@
+package org.palladiosimulator.analyzer.workflow.jobs;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+
+import de.uka.ipd.sdq.workflow.jobs.AbstractBlackboardInteractingJob;
+import de.uka.ipd.sdq.workflow.jobs.CleanupFailedException;
+import de.uka.ipd.sdq.workflow.jobs.JobFailedException;
+import de.uka.ipd.sdq.workflow.jobs.UserCanceledException;
+import de.uka.ipd.sdq.workflow.mdsd.blackboard.MDSDBlackboard;
+
+public class ResolveAllModelsOfPartitionJob extends AbstractBlackboardInteractingJob<MDSDBlackboard> {
+
+    private final String blackboardId;
+
+    public ResolveAllModelsOfPartitionJob(String blackboardId) {
+        this.blackboardId = blackboardId;
+    }
+    
+    @Override
+    public void execute(IProgressMonitor monitor) throws JobFailedException, UserCanceledException {
+        var partition = myBlackboard.getPartition(blackboardId);
+        
+        EcoreUtil.resolveAll(partition.getResourceSet());
+    }
+
+    @Override
+    public void cleanup(IProgressMonitor monitor) throws CleanupFailedException {
+    }
+
+    @Override
+    public String getName() {
+        return "Resolve all models of Partition \"" + blackboardId + "\"";
+    }
+
+}


### PR DESCRIPTION
Streamlined shared job library to reduce code duplication.

- CreateBlackboardPartitionJob
- LoadModelIntoBlackboardJob

Adapted existing jobs to use this basic jobs. Behavior of existing composed jobs is kept consistent. Furthermore, moved partition id constants into ConstantsContainer. I kept but deprecated the existing constant definitions, as these are used in several other projects.

I further removed the calls to ResourceSetPartition.initialiseResourceSetEPackages, as the used Package Registry is a global instance provided by EMF and initialization is done by EMF automatically. The only case where this does not apply, is when run in standalone mode. For this case, with the StandaloneInitializer we have a much better tooling by now.