### PR TITLE
removed check constraints according to WFE-86

### DIFF
--- a/bundles/org.palladiosimulator.analyzer.workflow/src/org/palladiosimulator/analyzer/workflow/jobs/ValidatePCMModelsJob.java
+++ b/bundles/org.palladiosimulator.analyzer.workflow/src/org/palladiosimulator/analyzer/workflow/jobs/ValidatePCMModelsJob.java
@@ -9,7 +9,6 @@ import de.uka.ipd.sdq.errorhandling.SeverityEnum;
 import de.uka.ipd.sdq.workflow.jobs.SequentialBlackboardInteractingJob;
 import de.uka.ipd.sdq.workflow.mdsd.blackboard.MDSDBlackboard;
 import de.uka.ipd.sdq.workflow.mdsd.emf.CheckEMFConstraintsJob;
-import de.uka.ipd.sdq.workflow.mdsd.oaw.PerformOAWCheckValidation;
 import de.uka.ipd.sdq.workflow.mdsd.validation.ModelValidationJob;
 import de.uka.ipd.sdq.workflow.mdsd.validation.ShowValidationErrorsJob;
 
@@ -22,7 +21,6 @@ import de.uka.ipd.sdq.workflow.mdsd.validation.ShowValidationErrorsJob;
 public class ValidatePCMModelsJob 
 extends SequentialBlackboardInteractingJob<MDSDBlackboard> {
 
-	private static final String PCM_CHECK_FILENAME = "pcm";
 	
 	/* (non-Javadoc)
 	 * @see de.uka.ipd.sdq.codegen.simucontroller.workflow.ISimulationJob#execute()


### PR DESCRIPTION
* The check constraints should be integrated within the metamodel, see [WFE-86](https://palladio-simulator.atlassian.net/browse/WFE-86)
* the simulation specific checks should be integrated within the simulation [ASE-3](https://palladio-simulator.atlassian.net/browse/ASE-3)
* should be merged together with [Palladio-Core-PCM](https://github.com/PalladioSimulator/Palladio-Core-PCM/pull/33)